### PR TITLE
Fixing the ConcurrentModificationException on init

### DIFF
--- a/src/main/java/spark/route/Routes.java
+++ b/src/main/java/spark/route/Routes.java
@@ -21,6 +21,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import spark.FilterImpl;
 import spark.RouteImpl;
@@ -49,7 +50,7 @@ public class Routes {
      * Constructor
      */
     protected Routes() {
-        routes = new ArrayList<>();
+        routes = new CopyOnWriteArrayList<>();
     }
 
     /**

--- a/src/test/java/spark/ConcurrentInitializationTest.java
+++ b/src/test/java/spark/ConcurrentInitializationTest.java
@@ -1,0 +1,75 @@
+package spark;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import spark.util.SparkTestUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import static org.junit.Assert.assertEquals;
+import static spark.Spark.get;
+
+public class ConcurrentInitializationTest {
+
+    private static final int NUM_HANDLERS = 10000;
+    private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentInitializationTest.class);
+
+    private volatile boolean isClientRunning = true;
+
+
+    /**
+     * Simulates the client which check the server health check awaiting for it to be up and running,
+     * for example k8s or other orchestrator or load balancer. It call health check in loop to
+     * figure out that the service is started
+     */
+    private void client(CountDownLatch latch, List<Object> exceptionList) {
+        SparkTestUtil testUtil = new SparkTestUtil(4567);
+        while (isClientRunning) {
+            try {
+                SparkTestUtil.UrlResponse response = testUtil.doMethod("GET", "/healthcheck", null);
+                Assert.assertEquals(200, response.status);
+                Assert.assertEquals("Hello World!", response.body);
+                latch.countDown();
+            } catch (Exception | Error e) {
+                exceptionList.add(e);
+                LOGGER.error("Client error", e);
+            }
+        }
+    }
+
+    /**
+     * Simulates the server with a long list of APIs to be initialized
+     */
+    private void initHandlers() {
+        for (int i = 0; i < NUM_HANDLERS; i++) {
+            get("/api" + i, (q, a) -> "Hello World!");
+        }
+    }
+
+    @Test
+    public void testInitialization() throws InterruptedException {
+        CountDownLatch latch = new CountDownLatch(5);
+        List<Object> exceptionList = new ArrayList<>();
+        get("/healthcheck", (q, a) -> "Hello World!");
+        // Run the client in its own Thread
+        Thread clientThread = new Thread(() -> client(latch, exceptionList));
+        clientThread.start();
+        latch.await();
+        initHandlers();
+        isClientRunning = false;
+        clientThread.join();
+        assertEquals(0, exceptionList.size());
+    }
+
+    @AfterClass
+    public static void tearDown() {
+        Spark.stop();
+    }
+
+}


### PR DESCRIPTION
_Reproducing PR https://github.com/perwendel/spark/pull/1210._

This PR fixes issue #1118

**Context**
Most of the modern microservices are running behind the orchestrator or load balancer, for example in the Kubernetes cluster. The orchestrator is designed to perform regular checks of the service using the health check API. The response of the health check API is the only way for the orchestrator to know that the is up and running. As soon as the orchestrator starts the service process, it runs an infite loop of the health check requests.

**Problem**
Spark starts listening to the network as soon as the first route is registered. The problem is that the first request can come to the service before all routes are registered: after the first route is registered, but before the last one is registered, at the same time with one of the routes being registered. In this case, Spark will iterate over the routes list (looking for the route to handle the request) at the same time as the list could be modified by initialization. It would cause the following exception and the 500 error code returned to the client as a result:
```
[qtp168818756-21] ERROR spark.http.matching.GeneralError - 
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1043)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:997)
	at spark.route.Routes.findTargetsForRequestedRoute(Routes.java:215)
	at spark.route.Routes.find(Routes.java:84)
	at spark.http.matching.Routes.execute(Routes.java:34)
	at spark.http.matching.MatcherFilter.doFilter(MatcherFilter.java:134)
	at spark.embeddedserver.jetty.JettyHandler.doHandle(JettyHandler.java:50)
	at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1586)
	at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
	at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
	at org.eclipse.jetty.server.Server.handle(Server.java:516)
	at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:383)
	at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:556)
	at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:375)
	at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:273)
	at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
	at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
	at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:336)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:313)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:171)
	at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:129)
	at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:375)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:773)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:905)
	at java.base/java.lang.Thread.run(Thread.java:834)
```

**Reproduction steps:**
Please see the test case included in the PR

**Solution:**
Change the implementation of the `routes` list inside the `Routes` class from `ArrayList` to `CopyOnWriteArrayList`. Internally, [CopyOnWriteArrayList](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CopyOnWriteArrayList.html) would be copied every time the new element is added, so there is no way it could have `ConcurrentModificationException` when iterating over it. It does not have any lock inside and hence iteration over it does not have any overhead compared to `ArrayList`. `ConcurrentModificationException` has an extra overhead when adding the routes, but since route, registration is one-time action during the service start and most of the microservices should have a relatively low amount of routes, it should not be a concern.